### PR TITLE
fruitDetection.py: Can't have an 'elif' if there is no 'if'

### DIFF
--- a/OPEN CHALLENGE/fruitDetection.py
+++ b/OPEN CHALLENGE/fruitDetection.py
@@ -162,7 +162,7 @@ def Orangecheck(x):
 
         return fruit
 
-    elif orangeSize == "not detected":
+    # elif orangeSize == "not detected":
 
     return "not detected"
 


### PR DESCRIPTION
@KomalBagai 

[flake8](http://flake8.pycqa.org) testing of https://github.com/hackerearthclub/CODE2RACE on Python 3.7.1

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./OPEN CHALLENGE/fruitDetection.py:165:8: E999 SyntaxError: invalid syntax
    elif orangeSize == "not detected":
       ^
1    E999 SyntaxError: invalid syntax
1
```